### PR TITLE
README: Add --clear to local deployment step

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Using docker and the NPL CLI, the project can be run locally:
 
 ```shell
 docker compose up -d --wait
-npl deploy --sourceDir api/src/main
+npl deploy --sourceDir api/src/main --clear
 ```
 
 Fetch a token from the embedded OIDC server with


### PR DESCRIPTION
In absence of migration outcome message when deploying, adding --clear flag so that users are not puzzled when their code changes (keeping NPL version unchanged) are effectively not reflected in deployed code.